### PR TITLE
Add max parameter for the Search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+* Add `max` parameter to search requests (thanks @lbrito1)
+
 ## [0.2.1] - 2023-07-06
 
 * Raise exception when `Podcast.find` returns no result ([#6](https://github.com/jasonyork/podcast-index/issues/6))

--- a/lib/podcast_index/api/search.rb
+++ b/lib/podcast_index/api/search.rb
@@ -1,29 +1,34 @@
+# rubocop:disable Metrics/ParameterLists
 module PodcastIndex
   module Api
     class Search
       extend Request
 
       class << self
-        def by_term(term:, val: nil, aponly: nil, clean: nil, fulltext: nil)
-          response = get("/search/byterm", q: term, val: val, aponly: aponly, clean: clean, fulltext: fulltext)
+        def by_term(term:, val: nil, aponly: nil, clean: nil, fulltext: nil, max: nil)
+          response = get("/search/byterm", q: term, val: val, aponly: aponly, clean: clean, fulltext: fulltext,
+                                           max: max)
           JSON.parse(response.body)
         end
 
-        def by_title(title:, val: nil, clean: nil, fulltext: nil, similar: nil)
-          response = get("/search/bytitle", q: title, val: val, clean: clean, fulltext: fulltext, similar: similar)
+        def by_title(title:, val: nil, clean: nil, fulltext: nil, similar: nil, max: nil)
+          response = get("/search/bytitle", q: title, val: val, clean: clean, fulltext: fulltext, similar: similar,
+                                            max: max)
           JSON.parse(response.body)
         end
 
-        def by_person(person:, fulltext: nil)
-          response = get("/search/byperson", q: person, fulltext: fulltext)
+        def by_person(person:, fulltext: nil, max: nil)
+          response = get("/search/byperson", q: person, fulltext: fulltext, max: max)
           JSON.parse(response.body)
         end
 
-        def music_by_term(term:, val: nil, aponly: nil, clean: nil, fulltext: nil)
-          response = get("/search/music/byterm", q: term, val: val, aponly: aponly, clean: clean, fulltext: fulltext)
+        def music_by_term(term:, val: nil, aponly: nil, clean: nil, fulltext: nil, max: nil)
+          response = get("/search/music/byterm", q: term, val: val, aponly: aponly, clean: clean, fulltext: fulltext,
+                                                 max: max)
           JSON.parse(response.body)
         end
       end
     end
   end
 end
+# rubocop:enable Metrics/ParameterLists

--- a/lib/podcast_index/episode.rb
+++ b/lib/podcast_index/episode.rb
@@ -66,8 +66,8 @@ module PodcastIndex
         from_response_collection(response)
       end
 
-      def find_all_by_person(person:, fulltext: nil)
-        response = Api::Search.by_person(person: person, fulltext: fulltext)
+      def find_all_by_person(person:, fulltext: nil, max: nil)
+        response = Api::Search.by_person(person: person, fulltext: fulltext, max: max)
         from_response_collection(response)
       end
 

--- a/lib/podcast_index/podcast.rb
+++ b/lib/podcast_index/podcast.rb
@@ -55,8 +55,9 @@ module PodcastIndex
         from_response_collection(response)
       end
 
-      def find_all_music_by_term(medium:, term:, val: nil, aponly: nil, clean: nil, fulltext: nil)
-        response = Api::Search.music_by_term(term: term, val: val, aponly: aponly, clean: clean, fulltext: fulltext)
+      def find_all_music_by_term(medium:, term:, val: nil, aponly: nil, clean: nil, fulltext: nil, max: nil)
+        response = Api::Search.music_by_term(term: term, val: val, aponly: aponly, clean: clean, fulltext: fulltext,
+                                             max: max)
         from_response_collection(response)
       end
 
@@ -76,13 +77,13 @@ module PodcastIndex
         from_response_collection(response)
       end
 
-      def find_all_by_term(term:, val: nil, aponly: nil, clean: nil, fulltext: nil)
-        response = Api::Search.by_term(term: term, val: val, aponly: aponly, clean: clean, fulltext: fulltext)
+      def find_all_by_term(term:, val: nil, aponly: nil, clean: nil, fulltext: nil, max: nil)
+        response = Api::Search.by_term(term: term, val: val, aponly: aponly, clean: clean, fulltext: fulltext, max: max)
         from_response_collection(response)
       end
 
-      def find_all_by_title(title:, val: nil, clean: nil, fulltext: nil)
-        response = Api::Search.by_title(title: title, val: val, clean: clean, fulltext: fulltext)
+      def find_all_by_title(title:, val: nil, clean: nil, fulltext: nil, max: nil)
+        response = Api::Search.by_title(title: title, val: val, clean: clean, fulltext: fulltext, max: max)
         from_response_collection(response)
       end
 


### PR DESCRIPTION
Hi,

The [Search](https://podcastindex-org.github.io/docs-api/#tag--Search) endpoints have a `max` parameter that was previously unsupported. 

Tried to keep up with the code style re: rubocop etc.